### PR TITLE
stop passing auth tokens via query parameters

### DIFF
--- a/lib/assembly.rb
+++ b/lib/assembly.rb
@@ -6,6 +6,7 @@ require "ostruct"
 require "faraday"
 require "faraday_middleware"
 
+require 'assembly/faraday_middleware/assembly_oauth2'
 require 'assembly/util'
 require 'assembly/config'
 require 'assembly/client'

--- a/lib/assembly/client.rb
+++ b/lib/assembly/client.rb
@@ -110,9 +110,9 @@ module Assembly
     end
 
     def build_api_adapter
-      @api                  = Faraday.new(:url => config.host) do |faraday|
+      @api = Faraday.new(:url => config.host) do |faraday|
         faraday.request :json
-        faraday.request :oauth2, config.token
+        faraday.request :assembly_oauth2, config.token
         faraday.response :json
         faraday.adapter Faraday.default_adapter
       end

--- a/lib/assembly/faraday_middleware/assembly_oauth2.rb
+++ b/lib/assembly/faraday_middleware/assembly_oauth2.rb
@@ -1,0 +1,25 @@
+require 'faraday'
+require 'forwardable'
+
+module FaradayMiddleware
+  class AssemblyOAuth2 < Faraday::Middleware
+    AUTH_HEADER = 'Authorization'.freeze
+
+    attr_reader :token
+
+    def call(env)
+      env[:request_headers][AUTH_HEADER] ||= "Bearer #{token}"
+      @app.call env
+    end
+
+    def initialize(app, token)
+      unless token && token.is_a?(String)
+        raise ArgumentError.new("An access_token string was expected, got: #{token.inspect}")
+      end
+      super(app)
+      @token = token
+    end
+  end
+end
+
+Faraday::Request.register_middleware(assembly_oauth2: FaradayMiddleware::AssemblyOAuth2)

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -30,12 +30,14 @@ describe Assembly::Client do
   end
 
   it "refreshes the token when a token_invalid response is given" do
-    stub_request(:get, "https://api.assembly.education/students?access_token=old_access_token").
-      with(headers: { 'Accept' => 'application/vnd.assembly+json; version=1' }).
+    stub_request(:get, "https://api.assembly.education/students").
+      with(headers: { 'Accept' => 'application/vnd.assembly+json; version=1',
+                      'Authorization'=>'Bearer old_access_token' }).
       to_return({ status: 401, body: '{"error": "invalid_token", "message": "token has expired"}' })
 
-    stub_request(:get, "https://api.assembly.education/students?access_token=new_access_token").
-      with(headers: { 'Accept' => 'application/vnd.assembly+json; version=1' }).
+    stub_request(:get, "https://api.assembly.education/students").
+      with(headers: { 'Accept' => 'application/vnd.assembly+json; version=1',
+                      'Authorization'=>'Bearer new_access_token' }).
       to_return({ status: 200, body: '{}' })
 
     stub_request(:post, "https://id:secret@platform.assembly.education/oauth/token").


### PR DESCRIPTION
We are migrating all clients to use Bearer tokens for the improved security of headers vs query string parameters.

The faraday `assembly_oauth2` middleware we were using doesn't support Bearer tokens and instead favours tokens as query string parameters.

I've written a very small faraday middleware to handle adding oauth Bearer tokens that replaces the official `oauth2` middleware.