### PR TITLE
Add a model/resource for listing academic_years

### DIFF
--- a/lib/assembly.rb
+++ b/lib/assembly.rb
@@ -27,6 +27,7 @@ require 'assembly/models/result'
 require 'assembly/models/teaching_group'
 require 'assembly/models/student'
 require 'assembly/models/staff_member'
+require 'assembly/models/academic_year'
 
 module Assembly
   @config = Config.new

--- a/lib/assembly/client.rb
+++ b/lib/assembly/client.rb
@@ -64,6 +64,10 @@ module Assembly
       Assembly::StaffMemberResource.new(self)
     end
 
+    def academic_years
+      Assembly::AcademicYearResource.new(self)
+    end
+
     def on_token_refresh(&blk)
       @on_token_refresh = blk
     end

--- a/lib/assembly/models/academic_year.rb
+++ b/lib/assembly/models/academic_year.rb
@@ -1,0 +1,7 @@
+module Assembly
+  class AcademicYear < ApiModel
+    include Assembly::Actions::List
+  end
+
+  Resource.build(AcademicYear)
+end

--- a/lib/assembly/version.rb
+++ b/lib/assembly/version.rb
@@ -1,3 +1,3 @@
 module Assembly
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end


### PR DESCRIPTION
A small change that introduces `client.academic_years.list` and `client.academic_years.all` into the `/academic_years` Assembly Platform endpoint.