### PR TITLE
216 MM compatibility

### DIFF
--- a/assembly.gemspec
+++ b/assembly.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday",            "~> 0.13.1"
+  spec.add_dependency "faraday",            "~> 0.12.2"
   spec.add_dependency "faraday_middleware", "~> 0.12.2"
 
   spec.add_development_dependency "bundler",            "~> 1.15"

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -15,7 +15,7 @@ describe Assembly::Client do
   it "runs a block when the token is refreshed" do
     stub_request(:post, "https://platform.assembly.education/oauth/token").
       with(:body => { "grant_type" => "refresh_token", "refresh_token" => "refresh_token" },
-        :headers => { 'Accept' => 'application/vnd.assembly+json; version=1', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Basic aWQ6c2VjcmV0', 'Content-Type' => 'application/x-www-form-urlencoded', 'User-Agent' => 'Faraday v0.13.1' }).
+        :headers => { 'Accept' => 'application/vnd.assembly+json; version=1', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Basic aWQ6c2VjcmV0', 'Content-Type' => 'application/x-www-form-urlencoded', 'User-Agent' => 'Faraday v0.12.2' }).
       to_return(status: 200, body: '{"access_token": "new_access_token"}')
 
 
@@ -42,7 +42,7 @@ describe Assembly::Client do
 
     stub_request(:post, "https://platform.assembly.education/oauth/token").
       with(:body => { "grant_type" => "refresh_token", "refresh_token" => "refresh_token" },
-        :headers => { 'Accept' => 'application/vnd.assembly+json; version=1', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Basic aWQ6c2VjcmV0', 'Content-Type' => 'application/x-www-form-urlencoded', 'User-Agent' => 'Faraday v0.13.1' }).
+        :headers => { 'Accept' => 'application/vnd.assembly+json; version=1', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Basic aWQ6c2VjcmV0', 'Content-Type' => 'application/x-www-form-urlencoded', 'User-Agent' => 'Faraday v0.12.2' }).
       to_return(status: 200, body: '{"access_token": "new_access_token"}')
 
     access_token = 'old_access_token'


### PR DESCRIPTION
This PR will:

* Adjust version of `faraday` gem for compatibility with MM

This is because MM uses the `oauth2` gem, which has a dependency on the `faraday` gem version < 13.0