### PR TITLE
Update Faraday version to remove 2.7.0 deprecation warnings and maint…

### DIFF
--- a/assembly-client.gemspec
+++ b/assembly-client.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday",            "~> 0.12.2"
-  spec.add_dependency "faraday_middleware", "~> 0.12.2"
+  spec.add_dependency "faraday",            "~> 1.0.1"
+  spec.add_dependency "faraday_middleware", "~> 1.0.0"
 
   spec.add_development_dependency "bundler",            "~> 1.15"
   spec.add_development_dependency "rake",               "~> 12.1"

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -15,7 +15,7 @@ describe Assembly::Client do
   it "runs a block when the token is refreshed" do
     stub_request(:post, "https://platform.assembly.education/oauth/token").
       with(:body => { "grant_type" => "refresh_token", "refresh_token" => "refresh_token" },
-        :headers => { 'Accept' => 'application/vnd.assembly+json; version=1', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Basic aWQ6c2VjcmV0', 'Content-Type' => 'application/x-www-form-urlencoded', 'User-Agent' => 'Faraday v0.12.2' }).
+        :headers => { 'Accept' => 'application/vnd.assembly+json; version=1', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Basic aWQ6c2VjcmV0', 'Content-Type' => 'application/x-www-form-urlencoded', 'User-Agent' => 'Faraday v1.0.1' }).
       to_return(status: 200, body: '{"access_token": "new_access_token"}')
 
 
@@ -42,7 +42,7 @@ describe Assembly::Client do
 
     stub_request(:post, "https://platform.assembly.education/oauth/token").
       with(:body => { "grant_type" => "refresh_token", "refresh_token" => "refresh_token" },
-        :headers => { 'Accept' => 'application/vnd.assembly+json; version=1', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Basic aWQ6c2VjcmV0', 'Content-Type' => 'application/x-www-form-urlencoded', 'User-Agent' => 'Faraday v0.12.2' }).
+        :headers => { 'Accept' => 'application/vnd.assembly+json; version=1', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Basic aWQ6c2VjcmV0', 'Content-Type' => 'application/x-www-form-urlencoded', 'User-Agent' => 'Faraday v1.0.1' }).
       to_return(status: 200, body: '{"access_token": "new_access_token"}')
 
     access_token = 'old_access_token'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,7 @@ require 'minitest/spec'
 require 'minitest/reporters'
 require 'minitest/mock'
 
-require 'mocha/mini_test'
+require 'mocha/minitest'
 require 'webmock/minitest'
 
 WebMock.disable_net_connect!


### PR DESCRIPTION
…ain support with newer versions of oauth2

The version of Faraday currently used results in deprecation warnings with Ruby 2.7.0. To solve this, I've updated to the latest versions of the Faraday gems, which are also supported by newer versions of the oauth2 gem.